### PR TITLE
Add toolchain with support for RasPi Zero

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,12 +1,15 @@
 # Use our custom-configured c++ toolchain.
 
 build:armeabi-v7a --crosstool_top=//tools/arm_compiler:toolchain
+build:armeabi-v6 --crosstool_top=//tools/arm_compiler:toolchain
 
 # Use --cpu as a differentiator.
 
 build:armeabi-v7a --cpu=armeabi-v7a
+build:armeabi-v6 --cpu=armeabi-v6
 
 # Use the default Bazel C++ toolchain to build the tools used during the
 # build.
 
 build:armeabi-v7a --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
+build:armeabi-v6 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Bazel ARM Toolchains
+
+[![Build Status](https://dev.azure.com/colinwilliamatkinson/bazel_arm_toolchain/_apis/build/status/colatkinson.bazel_arm_toolchain?branchName=master)](https://dev.azure.com/colinwilliamatkinson/bazel_arm_toolchain/_build/latest?definitionId=1&branchName=master)
+
+A couple of simple Bazel toolchains for cross-compiling for ARM.
+
+## Warning
+
+These are really, truly hacked together. They don't, for example, work with the
+newfangled platforms method, and instead use the legacy crosstool-based
+mechanism.
+
+I'm not a Bazel expert, and I have literally no idea what I'm doing. These are
+pretty much copied verbatim from an upstream [integration
+test](https://github.com/bazelbuild/bazel/tree/9606887fde143abedd19787be5187d47cc7e06a7/src/test/shell/bazel/testdata/bazel_toolchain_test_data).
+
+## Toolchains
+
+* `armeabi-v7a`: Uses the Linaro prebuilt toolchain for ARM V7A, which is supported some of the newer Raspberry Pi models (RPi 2 Model B and newer).
+* `armeabi-v6`: Uses the [Raspbian patched Linaro
+  toolchains](https://github.com/raspberrypi/tools/tree/master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64)
+  to support ARMv6, as found on the original RPi and the Zero models.
+
+## Usage
+
+Take a look at the test scripts. I'll eventually update this with more direct instructions.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,9 @@ jobs:
       bazel build //... --config=armeabi-v7a
       file bazel-bin/hello | grep "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV)"
     displayName: "Build"
+  - script:
+      ./scripts/armeabi-v7a-docker-test.sh
+    displayName: "Test"
 - job: armeabi_v6
   displayName: 'armeabi-v6'
   dependsOn: []
@@ -20,3 +23,6 @@ jobs:
       bazel build //... --config=armeabi-v6
       file bazel-bin/hello | grep "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV)"
     displayName: "Build"
+  - script:
+      ./scripts/armeabi-v6-docker-test.sh
+    displayName: "Test"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,11 +1,22 @@
 pool:
   vmImage: 'ubuntu-18.04'
 
-steps:
-- script: |
-    sudo apt-get install wget patch file
-    wget https://github.com/bazelbuild/bazel/releases/download/1.0.1/bazel_1.0.1-linux-x86_64.deb -O bazel.deb
-    sudo apt install ./bazel.deb
-    bazel build //... --config=armeabi-v7a
-    file bazel-bin/hello | grep "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV)"
-  displayName: 'Bazel build'
+jobs:
+- job: armeabi_v7a
+  displayName: 'armeabi-v7a'
+  dependsOn: []
+  steps:
+  - template: azure-templates/bazel-install-steps.yml
+  - script: |
+      bazel build //... --config=armeabi-v7a
+      file bazel-bin/hello | grep "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV)"
+    displayName: "Build"
+- job: armeabi_v6
+  displayName: 'armeabi-v6'
+  dependsOn: []
+  steps:
+  - template: azure-templates/bazel-install-steps.yml
+  - script: |
+      bazel build //... --config=armeabi-v6
+      file bazel-bin/hello | grep "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV)"
+    displayName: "Build"

--- a/azure-templates/bazel-install-steps.yml
+++ b/azure-templates/bazel-install-steps.yml
@@ -1,0 +1,6 @@
+steps:
+- script: |
+    sudo apt-get install wget patch file
+    wget https://github.com/bazelbuild/bazel/releases/download/1.0.1/bazel_1.0.1-linux-x86_64.deb -O bazel.deb
+    sudo apt install ./bazel.deb
+  displayName: "Install dependencies"

--- a/azure-templates/bazel-install-steps.yml
+++ b/azure-templates/bazel-install-steps.yml
@@ -3,4 +3,14 @@ steps:
     sudo apt-get install wget patch file
     wget https://github.com/bazelbuild/bazel/releases/download/1.0.1/bazel_1.0.1-linux-x86_64.deb -O bazel.deb
     sudo apt install ./bazel.deb
-  displayName: "Install dependencies"
+  displayName: "Install Bazel"
+- script: |
+    sudo apt install apt-transport-https ca-certificates software-properties-common
+    wget https://download.docker.com/linux/ubuntu/gpg -O - | sudo apt-key add -
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
+    sudo apt update
+    sudo apt install docker-ce
+  displayName: "Install Docker"
+- script: |
+    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  displayName: "Start qemu-user-static"

--- a/compilers/raspi_linux_gcc_4.8.3.BUILD
+++ b/compilers/raspi_linux_gcc_4.8.3.BUILD
@@ -1,0 +1,81 @@
+package(default_visibility = ['//visibility:public'])
+
+filegroup(
+  name = 'gcc',
+  srcs = [
+    'bin/arm-linux-gnueabihf-gcc',
+  ],
+)
+
+filegroup(
+  name = 'ar',
+  srcs = [
+    'bin/arm-linux-gnueabihf-ar',
+  ],
+)
+
+filegroup(
+  name = 'ld',
+  srcs = [
+    'bin/arm-linux-gnueabihf-ld',
+  ],
+)
+
+filegroup(
+  name = 'nm',
+  srcs = [
+    'bin/arm-linux-gnueabihf-nm',
+  ],
+)
+
+filegroup(
+  name = 'objcopy',
+  srcs = [
+    'bin/arm-linux-gnueabihf-objcopy',
+  ],
+)
+
+filegroup(
+  name = 'objdump',
+  srcs = [
+    'bin/arm-linux-gnueabihf-objdump',
+  ],
+)
+
+filegroup(
+  name = 'strip',
+  srcs = [
+    'bin/arm-linux-gnueabihf-strip',
+  ],
+)
+
+filegroup(
+  name = 'as',
+  srcs = [
+    'bin/arm-linux-gnueabihf-as',
+  ],
+)
+
+filegroup(
+  name = 'compiler_pieces',
+  srcs = glob([
+    'arm-linux-gnueabihf/**',
+    'libexec/**',
+    'lib/gcc/arm-linux-gnueabihf/**',
+    'include/**',
+  ]),
+)
+
+filegroup(
+  name = 'compiler_components',
+  srcs = [
+    ':gcc',
+    ':ar',
+    ':ld',
+    ':nm',
+    ':objcopy',
+    ':objdump',
+    ':strip',
+    ':as',
+  ],
+)

--- a/compilers/raspi_linux_gcc_4.8.3.BUILD
+++ b/compilers/raspi_linux_gcc_4.8.3.BUILD
@@ -79,3 +79,47 @@ filegroup(
     ':as',
   ],
 )
+
+load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_deb")
+
+pkg_tar(
+    name = "libc_tar",
+    strip_prefix = "./arm-linux-gnueabihf/libc",
+    srcs = glob([
+        "arm-linux-gnueabihf/libc/**/*.so*"
+    ],
+    exclude = [
+        # We don't care about debug symbols
+        "**/debug/**",
+        # We definitely don't care about manpages
+        "**/man/**",
+        # We're already statically linking this
+        "**/libm*.so*",
+        # We're going to symlink this
+        "**/libc.so.6",
+    ]),
+)
+
+# TODO(colin): Not sure if we actually need these...
+# pkg_tar(
+#     name = "lib_tar",
+#     strip_prefix = "./arm-linux-gnueabihf",
+#     srcs = glob([
+#       'arm-linux-gnueabihf/lib/**/*.so*',
+#     ],
+#     exclude = [
+#         "**/debug/**",
+#     ]),
+# )
+
+pkg_tar(
+    name = "raspi_libs",
+    deps = [
+        ":libc_tar",
+    ],
+    # TODO(colin): Automate this process to remove *all* duplicate files
+    symlinks = {
+        "./lib/arm-linux-gnueabihf/libc.so.6": "libc-2.13.so",
+    },
+    visibility = ["//visibility:public"]
+)

--- a/hello.cc
+++ b/hello.cc
@@ -16,8 +16,21 @@
 #include <cstdlib>
 #include <ctime>
 #include <iostream>
+#include <thread>
+#include <atomic>
 
 int main(int argc, char* argv[]) {
   std::cout << "Hello! sqrt(time) = " << std::sqrt(time(NULL)) << std::endl;
+
+  std::atomic<int> val(1);
+
+  std::thread t([&val]() {
+    ++val;
+    std::cout << "Ahoy, me lads!" << std::endl;
+  });
+  t.join();
+
+  std::cout << "Val is " << val << std::endl;
+
   return EXIT_SUCCESS;
 }

--- a/patches/raspi_linux_gcc.patch
+++ b/patches/raspi_linux_gcc.patch
@@ -1,0 +1,20 @@
+diff --git a/arm-linux-gnueabihf/libc/usr/lib/arm-linux-gnueabihf/libc.so b/arm-linux-gnueabihf/libc/usr/lib/arm-linux-gnueabihf/libc.so
+index 82684ab0..e0cb2a24 100644
+--- a/arm-linux-gnueabihf/libc/usr/lib/arm-linux-gnueabihf/libc.so
++++ b/arm-linux-gnueabihf/libc/usr/lib/arm-linux-gnueabihf/libc.so
+@@ -2,4 +2,4 @@
+    Use the shared library, but some functions are only in
+    the static library, so try that secondarily.  */
+ OUTPUT_FORMAT(elf32-littlearm)
+-GROUP ( /lib/arm-linux-gnueabihf/libc.so.6 /usr/lib/arm-linux-gnueabihf/libc_nonshared.a  AS_NEEDED ( /lib/arm-linux-gnueabihf/ld-linux-armhf.so.3 ) )
++GROUP ( ../../lib/arm-linux-gnueabihf/libc.so.6 ./libc_nonshared.a  AS_NEEDED ( ../../lib/arm-linux-gnueabihf/ld-linux-armhf.so.3 ) )
+diff --git a/arm-linux-gnueabihf/libc/usr/lib/arm-linux-gnueabihf/libpthread.so b/arm-linux-gnueabihf/libc/usr/lib/arm-linux-gnueabihf/libpthread.so
+index 3cb92913..865bad2e 100644
+--- a/arm-linux-gnueabihf/libc/usr/lib/arm-linux-gnueabihf/libpthread.so
++++ b/arm-linux-gnueabihf/libc/usr/lib/arm-linux-gnueabihf/libpthread.so
+@@ -2,4 +2,4 @@
+    Use the shared library, but some functions are only in
+    the static library, so try that secondarily.  */
+ OUTPUT_FORMAT(elf32-littlearm)
+-GROUP ( /lib/arm-linux-gnueabihf/libpthread.so.0 /usr/lib/arm-linux-gnueabihf/libpthread_nonshared.a )
++GROUP ( ../../lib/arm-linux-gnueabihf/libpthread.so.0 ./libpthread_nonshared.a )

--- a/scripts/armeabi-v6-docker-test-container.sh
+++ b/scripts/armeabi-v6-docker-test-container.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo
+echo "IN CONTAINER"
+uname -a
+echo
+
+set -ex
+
+cp -R libc/* /
+cp -R stdlib/* /lib
+/hello

--- a/scripts/armeabi-v6-docker-test-container.sh
+++ b/scripts/armeabi-v6-docker-test-container.sh
@@ -7,6 +7,6 @@ echo
 
 set -ex
 
-cp -R libc/* /
-cp -R stdlib/* /lib
+tar xf libs.tar
+ldd /hello || true
 /hello

--- a/scripts/armeabi-v6-docker-test.sh
+++ b/scripts/armeabi-v6-docker-test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash --norc
+
+set -ex
+
+cur_dir_name=$(basename $PWD)
+
+tag=":1.31.1"
+digest="@sha256:dae90d3bd4540923ae86f945deca20ac693143b9b7ce02bb80bbfa2a8aecb576"
+
+docker run \
+    --env QEMU_CPU=arm1176 \
+    -v "$PWD/bazel-bin/hello":/hello:ro \
+    -v "$PWD/scripts/armeabi-v6-docker-test-container.sh":/run.sh:ro \
+    -v "$PWD/bazel-$cur_dir_name/external/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/libc":/libc:ro \
+    -v "$PWD/bazel-$cur_dir_name/external/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/lib":/stdlib:ro \
+    --rm arm32v6/busybox${digest} /run.sh

--- a/scripts/armeabi-v6-docker-test.sh
+++ b/scripts/armeabi-v6-docker-test.sh
@@ -2,6 +2,9 @@
 
 set -ex
 
+bazel build //:hello --config=armeabi-v6
+bazel build @raspi_components_toolchain_gcc_4_8_3//:raspi_libs --config=armeabi-v6
+
 cur_dir_name=$(basename $PWD)
 
 tag=":1.31.1"
@@ -11,6 +14,5 @@ docker run \
     --env QEMU_CPU=arm1176 \
     -v "$PWD/bazel-bin/hello":/hello:ro \
     -v "$PWD/scripts/armeabi-v6-docker-test-container.sh":/run.sh:ro \
-    -v "$PWD/bazel-$cur_dir_name/external/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/libc":/libc:ro \
-    -v "$PWD/bazel-$cur_dir_name/external/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/lib":/stdlib:ro \
+    -v "$PWD/bazel-bin/external/raspi_components_toolchain_gcc_4_8_3/raspi_libs.tar":/libs.tar:ro \
     --rm arm32v6/busybox${digest} /run.sh

--- a/scripts/armeabi-v7a-docker-test-container.sh
+++ b/scripts/armeabi-v7a-docker-test-container.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo
+echo "IN CONTAINER"
+uname -a
+echo
+
+set -ex
+
+apt-get update -y
+apt-get install -y libatomic1
+/hello

--- a/scripts/armeabi-v7a-docker-test-container.sh
+++ b/scripts/armeabi-v7a-docker-test-container.sh
@@ -7,6 +7,4 @@ echo
 
 set -ex
 
-apt-get update -y
-apt-get install -y libatomic1
 /hello

--- a/scripts/armeabi-v7a-docker-test.sh
+++ b/scripts/armeabi-v7a-docker-test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash --norc
+
+set -ex
+
+cur_dir_name=$(basename $PWD)
+
+tag=":buster-slim"
+digest="@sha256:6bf2a3c5837a79ab1915b980c2bde22322d6b38a9d0df12f01c3e2a56c433bc5"
+
+docker run \
+    -v "$PWD/bazel-bin/hello":/hello:ro \
+    -v "$PWD/scripts/armeabi-v7a-docker-test-container.sh":/run.sh:ro \
+    --rm arm32v7/debian${digest} /run.sh

--- a/scripts/armeabi-v7a-docker-test.sh
+++ b/scripts/armeabi-v7a-docker-test.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+bazel build //:hello --config=armeabi-v7a
+
 cur_dir_name=$(basename $PWD)
 
 tag=":buster-slim"

--- a/toolchains/repositories.bzl
+++ b/toolchains/repositories.bzl
@@ -1,7 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def arm_toolchains_repositories():
+    rules_pkg()
     org_linaro_components_toolchain_gcc_5_3_1()
+    raspi_components_toolchain_gcc_4_8_3()
 
 def org_linaro_components_toolchain_gcc_5_3_1():
     http_archive(
@@ -12,4 +14,24 @@ def org_linaro_components_toolchain_gcc_5_3_1():
         patches = ['@site_colatkinson_arm_toolchain//:patches/linaro_arm_linux.patch'],
         patch_args = ["-p1"],
         sha256 = "987941c9fffdf56ffcbe90e8984673c16648c477b537fcf43add22fa62f161cd",
+    )
+
+def raspi_components_toolchain_gcc_4_8_3():
+    toolchain_commit = '4a335520900ce55e251ac4f420f52bf0b2ab6b1f'
+
+    http_archive(
+        name = 'raspi_components_toolchain_gcc_4_8_3',
+        build_file = '@site_colatkinson_arm_toolchain//:compilers/raspi_linux_gcc_4.8.3.BUILD',
+        url = 'https://github.com/raspberrypi/tools/archive/%s.zip' % toolchain_commit,
+        strip_prefix = 'tools-%s/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64' % toolchain_commit,
+        patches = ['@site_colatkinson_arm_toolchain//:patches/raspi_linux_gcc.patch'],
+        patch_args = ["-p1"],
+        sha256 = "55ce12ae5246fa1f77410f730551cb63c8977cbf21828dddc99ebcba0b53530f",
+    )
+
+def rules_pkg():
+    http_archive(
+        name = "rules_pkg",
+        url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.4/rules_pkg-0.2.4.tar.gz",
+        sha256 = "4ba8f4ab0ff85f2484287ab06c0d871dcb31cc54d439457d28fd4ae14b18450a",
     )

--- a/tools/arm_compiler/BUILD
+++ b/tools/arm_compiler/BUILD
@@ -15,6 +15,7 @@ filegroup(
         ":cc-compiler-k8",
         ":linaro_linux_all_files",
         "@org_linaro_components_toolchain_gcc_5_3_1//:compiler_components",
+        "@raspi_components_toolchain_gcc_4_8_3//:compiler_components",
     ],
 )
 
@@ -32,8 +33,10 @@ cc_toolchain_suite(
     # target_cpu | compiler
     toolchains = {
         "armeabi-v7a": "cc-compiler-armeabi-v7a",
+        "armeabi-v6": "cc-compiler-armeabi-v6",
         "k8": "cc-compiler-k8",
         "armeabi-v7a|gcc": "cc-compiler-armeabi-v7a",
+        "armeabi-v6|gcc": "cc-compiler-armeabi-v6",
         "k8|compiler": "cc-compiler-k8",
     },
     visibility = ["//visibility:public"],
@@ -105,4 +108,50 @@ cc_toolchain(
     objcopy_files = ":empty",
     strip_files = ":empty",
     supports_param_files = 1,
+)
+
+filegroup(
+    name = "raspi_linux_all_files",
+    srcs = [
+        "//tools/arm_compiler/raspi_linux_gcc:tool-wrappers",
+        "@raspi_components_toolchain_gcc_4_8_3//:compiler_pieces",
+    ],
+)
+
+filegroup(
+    name = "raspi_linux_linker_files",
+    srcs = [
+        "//tools/arm_compiler/raspi_linux_gcc:ar",
+        "//tools/arm_compiler/raspi_linux_gcc:gcc",
+        "//tools/arm_compiler/raspi_linux_gcc:ld",
+        "@raspi_components_toolchain_gcc_4_8_3//:compiler_pieces",
+    ],
+)
+
+filegroup(
+    name = "raspi_linux_compiler_files",
+    srcs = [
+        "//tools/arm_compiler/raspi_linux_gcc:as",
+        "//tools/arm_compiler/raspi_linux_gcc:gcc",
+        "//tools/arm_compiler/raspi_linux_gcc:ld",
+        "@raspi_components_toolchain_gcc_4_8_3//:compiler_pieces",
+    ],
+)
+
+cc_toolchain_config(name = "armeabi-v6_config", cpu = "armeabi-v6", visibility = ["//visibility:public"])
+
+cc_toolchain(
+    name = "cc-compiler-armeabi-v6",
+    toolchain_identifier = "armeabi-v6",
+    toolchain_config = ":armeabi-v6_config",
+    all_files = ":raspi_linux_all_files",
+    ar_files = "//tools/arm_compiler/raspi_linux_gcc:ar",
+    as_files = "//tools/arm_compiler/raspi_linux_gcc:as",
+    compiler_files = ":raspi_linux_compiler_files",
+    dwp_files = ":empty",
+    linker_files = ":raspi_linux_linker_files",
+    objcopy_files = "//tools/arm_compiler/raspi_linux_gcc:objcopy",
+    strip_files = "//tools/arm_compiler/raspi_linux_gcc:strip",
+    supports_param_files = 1,
+    visibility = ["//visibility:public"],
 )

--- a/tools/arm_compiler/cc_toolchain_config.bzl
+++ b/tools/arm_compiler/cc_toolchain_config.bzl
@@ -33,6 +33,8 @@ load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 def _impl(ctx):
     if (ctx.attr.cpu == "armeabi-v7a"):
         toolchain_identifier = "armeabi-v7a"
+    elif (ctx.attr.cpu == "armeabi-v6"):
+        toolchain_identifier = "armeabi-v6"
     elif (ctx.attr.cpu == "k8"):
         toolchain_identifier = "local"
     else:
@@ -40,6 +42,8 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "armeabi-v7a"):
         host_system_name = "armeabi-v7a"
+    elif (ctx.attr.cpu == "armeabi-v6"):
+        host_system_name = "armeabi-v6"
     elif (ctx.attr.cpu == "k8"):
         host_system_name = "local"
     else:
@@ -47,6 +51,8 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "armeabi-v7a"):
         target_system_name = "arm_a15"
+    elif (ctx.attr.cpu == "armeabi-v6"):
+        target_system_name = "arm_1176"
     elif (ctx.attr.cpu == "k8"):
         target_system_name = "local"
     else:
@@ -54,12 +60,16 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "armeabi-v7a"):
         target_cpu = "armeabi-v7a"
+    elif (ctx.attr.cpu == "armeabi-v6"):
+        target_cpu = "armeabi-v6"
     elif (ctx.attr.cpu == "k8"):
         target_cpu = "k8"
     else:
         fail("Unreachable")
 
     if (ctx.attr.cpu == "armeabi-v7a"):
+        target_libc = "glibc_2.19"
+    elif (ctx.attr.cpu == "armeabi-v6"):
         target_libc = "glibc_2.19"
     elif (ctx.attr.cpu == "k8"):
         target_libc = "local"
@@ -70,10 +80,14 @@ def _impl(ctx):
         compiler = "compiler"
     elif (ctx.attr.cpu == "armeabi-v7a"):
         compiler = "gcc"
+    elif (ctx.attr.cpu == "armeabi-v6"):
+        compiler = "gcc"
     else:
         fail("Unreachable")
 
     if (ctx.attr.cpu == "armeabi-v7a"):
+        abi_version = "gcc"
+    elif (ctx.attr.cpu == "armeabi-v6"):
         abi_version = "gcc"
     elif (ctx.attr.cpu == "k8"):
         abi_version = "local"
@@ -81,6 +95,8 @@ def _impl(ctx):
         fail("Unreachable")
 
     if (ctx.attr.cpu == "armeabi-v7a"):
+        abi_libc_version = "glibc_2.19"
+    elif (ctx.attr.cpu == "armeabi-v6"):
         abi_libc_version = "glibc_2.19"
     elif (ctx.attr.cpu == "k8"):
         abi_libc_version = "local"
@@ -103,6 +119,14 @@ def _impl(ctx):
             enabled = True,
             tools = [
                 tool(path = "linaro_linux_gcc/arm-linux-gnueabihf-objcopy"),
+            ],
+        )
+    elif (ctx.attr.cpu == "armeabi-v6"):
+        objcopy_embed_data_action = action_config(
+            action_name = "objcopy_embed_data",
+            enabled = True,
+            tools = [
+                tool(path = "raspi_linux_gcc/arm-linux-gnueabihf-objcopy"),
             ],
         )
     elif (ctx.attr.cpu == "k8"):
@@ -148,7 +172,7 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "armeabi-v7a"):
+    elif (ctx.attr.cpu == "armeabi-v7a" or ctx.attr.cpu == "armeabi-v6"):
         unfiltered_compile_flags_feature = feature(
             name = "unfiltered_compile_flags",
             enabled = True,
@@ -292,6 +316,121 @@ def _impl(ctx):
                                 "external/org_linaro_components_toolchain_gcc_5_3_1/include/c++/5.3.1/arm-linux-gnueabihf",
                                 "-isystem",
                                 "external/org_linaro_components_toolchain_gcc_5_3_1/include/c++/5.3.1",
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+    elif (ctx.attr.cpu == "armeabi-v6"):
+        default_compile_flags_feature = feature(
+            name = "default_compile_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.preprocess_assemble,
+                        ACTION_NAMES.linkstamp_compile,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.lto_backend,
+                        ACTION_NAMES.clif_match,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "--sysroot=external/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/libc",
+                                "-mfloat-abi=hard",
+                                "-nostdinc",
+                                "-isystem",
+                                "external/raspi_components_toolchain_gcc_4_8_3/lib/gcc/arm-linux-gnueabihf/4.8.3/include",
+                                "-isystem",
+                                "external/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/libc/usr/include",
+                                "-isystem",
+                                "external/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/libc/usr/include/arm-linux-gnueabihf",
+                                "-isystem",
+                                "external/raspi_components_toolchain_gcc_4_8_3/lib/gcc/arm-linux-gnueabihf/4.8.3/include-fixed",
+                                "-isystem",
+                                "external/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/libc/usr/include",
+                                "-U_FORTIFY_SOURCE",
+                                "-fstack-protector",
+                                "-fPIE",
+                                # "-fdiagnostics-color=always",
+                                "-Wall",
+                                "-Wunused-but-set-parameter",
+                                "-Wno-free-nonheap-object",
+                                "-fno-omit-frame-pointer",
+                            ],
+                        ),
+                    ],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.preprocess_assemble,
+                        ACTION_NAMES.linkstamp_compile,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.lto_backend,
+                        ACTION_NAMES.clif_match,
+                    ],
+                    flag_groups = [flag_group(flags = ["-g"])],
+                    with_features = [with_feature_set(features = ["dbg"])],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.preprocess_assemble,
+                        ACTION_NAMES.linkstamp_compile,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.lto_backend,
+                        ACTION_NAMES.clif_match,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-g0",
+                                "-O2",
+                                "-DNDEBUG",
+                                "-ffunction-sections",
+                                "-fdata-sections",
+                            ],
+                        ),
+                    ],
+                    with_features = [with_feature_set(features = ["opt"])],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.linkstamp_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.lto_backend,
+                        ACTION_NAMES.clif_match,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-isystem",
+                                "external/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/include/c++/4.8.3/arm-linux-gnueabihf",
+                                "-isystem",
+                                "external/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/include/c++/4.8.3",
+                                "-isystem",
+                                "external/raspi_components_toolchain_gcc_4_8_3/include/c++/4.8.3/arm-linux-gnueabihf",
+                                "-isystem",
+                                "external/raspi_components_toolchain_gcc_4_8_3/include/c++/4.8.3",
                             ],
                         ),
                     ],
@@ -486,6 +625,41 @@ def _impl(ctx):
                 ),
             ],
         )
+    elif (ctx.attr.cpu == "armeabi-v6"):
+        default_link_flags_feature = feature(
+            name = "default_link_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = all_link_actions,
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "--sysroot=external/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/libc",
+                                "-lstdc++",
+                                "-latomic",
+                                "-lm",
+                                "-lpthread",
+                                "-Ltools/arm_compiler/linaro_linux_gcc/clang_more_libs",
+                                "-Lexternal/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/lib",
+                                "-Lexternal/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/libc/lib",
+                                "-Lexternal/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/libc/usr/lib",
+                                "-Bexternal/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/bin",
+                                "-Wl,--dynamic-linker=/lib/ld-linux-armhf.so.3",
+                                "-no-canonical-prefixes",
+                                "-pie",
+                                "-Wl,-z,relro,-z,now",
+                            ],
+                        ),
+                    ],
+                ),
+                flag_set(
+                    actions = all_link_actions,
+                    flag_groups = [flag_group(flags = ["-Wl,--gc-sections"])],
+                    with_features = [with_feature_set(features = ["opt"])],
+                ),
+            ],
+        )
     elif (ctx.attr.cpu == "k8"):
         default_link_flags_feature = feature(
             name = "default_link_flags",
@@ -540,7 +714,7 @@ def _impl(ctx):
             sysroot_feature,
             unfiltered_compile_flags_feature,
         ]
-    elif (ctx.attr.cpu == "armeabi-v7a"):
+    elif (ctx.attr.cpu == "armeabi-v7a" or ctx.attr.cpu == "armeabi-v6"):
         features = [
             default_compile_flags_feature,
             default_link_flags_feature,
@@ -567,6 +741,20 @@ def _impl(ctx):
             "%package(@org_linaro_components_toolchain_gcc_5_3_1//lib/gcc/arm-linux-gnueabihf/5.3.1/include)%",
             "%package(@org_linaro_components_toolchain_gcc_5_3_1//lib/gcc/arm-linux-gnueabihf/5.3.1/include-fixed)%",
             "%package(@org_linaro_components_toolchain_gcc_5_3_1//arm-linux-gnueabihf/include)%/c++/5.3.1",
+        ]
+    elif (ctx.attr.cpu == "armeabi-v6"):
+        cxx_builtin_include_directories = [
+            "%package(@raspi_components_toolchain_gcc_4_8_3//include)%",
+            "%package(@raspi_components_toolchain_gcc_4_8_3//arm-linux-gnueabihf/libc/usr/include)%",
+            "%package(@raspi_components_toolchain_gcc_5_3_1//arm-linux-gnueabihf/libc/usr/include/arm-linux-gnueabihf)%",
+            "%package(@raspi_components_toolchain_gcc_4_8_3//arm-linux-gnueabihf/libc/usr/lib/include)%",
+            "%package(@raspi_components_toolchain_gcc_4_8_3//arm-linux-gnueabihf/libc/lib/gcc/arm-linux-gnueabihf/4.8.3/include-fixed)%",
+            "%package(@raspi_components_toolchain_gcc_4_8_3//include)%/c++/4.8.3",
+            "%package(@raspi_components_toolchain_gcc_4_8_3//arm-linux-gnueabihf/libc/lib/gcc/arm-linux-gnueabihf/4.8.3/include)%",
+            "%package(@raspi_components_toolchain_gcc_4_8_3//arm-linux-gnueabihf/libc/lib/gcc/arm-linux-gnueabihf/4.8.3/include-fixed)%",
+            "%package(@raspi_components_toolchain_gcc_4_8_3//lib/gcc/arm-linux-gnueabihf/4.8.3/include)%",
+            "%package(@raspi_components_toolchain_gcc_4_8_3//lib/gcc/arm-linux-gnueabihf/4.8.3/include-fixed)%",
+            "%package(@raspi_components_toolchain_gcc_4_8_3//arm-linux-gnueabihf/include)%/c++/4.8.3",
         ]
     elif (ctx.attr.cpu == "k8"):
         cxx_builtin_include_directories = [
@@ -633,6 +821,53 @@ def _impl(ctx):
                 path = "linaro_linux_gcc/arm-linux-gnueabihf-strip",
             ),
         ]
+    elif (ctx.attr.cpu == "armeabi-v6"):
+        tool_paths = [
+            tool_path(
+                name = "ar",
+                path = "raspi_linux_gcc/arm-linux-gnueabihf-ar",
+            ),
+            tool_path(
+                name = "compat-ld",
+                path = "raspi_linux_gcc/arm-linux-gnueabihf-ld",
+            ),
+            tool_path(
+                name = "cpp",
+                path = "raspi_linux_gcc/arm-linux-gnueabihf-gcc",
+            ),
+            tool_path(
+                name = "dwp",
+                path = "raspi_linux_gcc/arm-linux-gnueabihf-dwp",
+            ),
+            tool_path(
+                name = "gcc",
+                path = "raspi_linux_gcc/arm-linux-gnueabihf-gcc",
+            ),
+            tool_path(
+                name = "gcov",
+                path = "arm-frc-linux-gnueabi/arm-frc-linux-gnueabi-gcov-4.9",
+            ),
+            tool_path(
+                name = "ld",
+                path = "raspi_linux_gcc/arm-linux-gnueabihf-ld",
+            ),
+            tool_path(
+                name = "nm",
+                path = "raspi_linux_gcc/arm-linux-gnueabihf-nm",
+            ),
+            tool_path(
+                name = "objcopy",
+                path = "raspi_linux_gcc/arm-linux-gnueabihf-objcopy",
+            ),
+            tool_path(
+                name = "objdump",
+                path = "raspi_linux_gcc/arm-linux-gnueabihf-objdump",
+            ),
+            tool_path(
+                name = "strip",
+                path = "raspi_linux_gcc/arm-linux-gnueabihf-strip",
+            ),
+        ]
     elif (ctx.attr.cpu == "k8"):
         tool_paths = [
             tool_path(name = "ar", path = "/usr/bin/ar"),
@@ -679,7 +914,7 @@ def _impl(ctx):
 cc_toolchain_config = rule(
     implementation = _impl,
     attrs = {
-        "cpu": attr.string(mandatory = True, values = ["armeabi-v7a", "k8"]),
+        "cpu": attr.string(mandatory = True, values = ["armeabi-v7a", "armeabi-v6", "k8"]),
     },
     provides = [CcToolchainConfigInfo],
     executable = True,

--- a/tools/arm_compiler/cc_toolchain_config.bzl
+++ b/tools/arm_compiler/cc_toolchain_config.bzl
@@ -308,6 +308,7 @@ def _impl(ctx):
                     flag_groups = [
                         flag_group(
                             flags = [
+                                "-std=c++11",
                                 "-isystem",
                                 "external/org_linaro_components_toolchain_gcc_5_3_1/arm-linux-gnueabihf/include/c++/5.3.1/arm-linux-gnueabihf",
                                 "-isystem",
@@ -423,6 +424,7 @@ def _impl(ctx):
                     flag_groups = [
                         flag_group(
                             flags = [
+                                "-std=c++11",
                                 "-isystem",
                                 "external/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/include/c++/4.8.3/arm-linux-gnueabihf",
                                 "-isystem",
@@ -602,7 +604,9 @@ def _impl(ctx):
                             flags = [
                                 "--sysroot=external/org_linaro_components_toolchain_gcc_5_3_1/arm-linux-gnueabihf/libc",
                                 "-lstdc++",
+                                "-Wl,-Bstatic",
                                 "-latomic",
+                                "-Wl,-Bdynamic",
                                 "-lm",
                                 "-lpthread",
                                 "-Ltools/arm_compiler/linaro_linux_gcc/clang_more_libs",
@@ -636,9 +640,13 @@ def _impl(ctx):
                         flag_group(
                             flags = [
                                 "--sysroot=external/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/libc",
+                                "-static-libgcc",
+                                "-static-libstdc++",
+                                "-Wl,-Bstatic",
                                 "-lstdc++",
                                 "-latomic",
                                 "-lm",
+                                "-Wl,-Bdynamic",
                                 "-lpthread",
                                 "-Ltools/arm_compiler/linaro_linux_gcc/clang_more_libs",
                                 "-Lexternal/raspi_components_toolchain_gcc_4_8_3/arm-linux-gnueabihf/lib",

--- a/tools/arm_compiler/raspi_linux_gcc/BUILD
+++ b/tools/arm_compiler/raspi_linux_gcc/BUILD
@@ -1,0 +1,85 @@
+package(default_visibility = ["//tools/arm_compiler:__pkg__"])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//tools/arm_compiler:__pkg__"],
+)
+
+filegroup(
+    name = "gcc",
+    srcs = [
+        "arm-linux-gnueabihf-gcc",
+        "@raspi_components_toolchain_gcc_4_8_3//:gcc",
+    ],
+)
+
+filegroup(
+    name = "ar",
+    srcs = [
+        "arm-linux-gnueabihf-ar",
+        "@raspi_components_toolchain_gcc_4_8_3//:ar",
+    ],
+)
+
+filegroup(
+    name = "ld",
+    srcs = [
+        "arm-linux-gnueabihf-ld",
+        "@raspi_components_toolchain_gcc_4_8_3//:ld",
+    ],
+)
+
+filegroup(
+    name = "nm",
+    srcs = [
+        "arm-linux-gnueabihf-nm",
+        "@raspi_components_toolchain_gcc_4_8_3//:nm",
+    ],
+)
+
+filegroup(
+    name = "objcopy",
+    srcs = [
+        "arm-linux-gnueabihf-objcopy",
+        "@raspi_components_toolchain_gcc_4_8_3//:objcopy",
+    ],
+)
+
+filegroup(
+    name = "objdump",
+    srcs = [
+        "arm-linux-gnueabihf-objdump",
+        "@raspi_components_toolchain_gcc_4_8_3//:objdump",
+    ],
+)
+
+filegroup(
+    name = "strip",
+    srcs = [
+        "arm-linux-gnueabihf-strip",
+        "@raspi_components_toolchain_gcc_4_8_3//:strip",
+    ],
+)
+
+filegroup(
+    name = "as",
+    srcs = [
+        "arm-linux-gnueabihf-as",
+        "@raspi_components_toolchain_gcc_4_8_3//:as",
+    ],
+)
+
+filegroup(
+    name = "tool-wrappers",
+    srcs = [
+        ":ar",
+        ":as",
+        ":gcc",
+        ":ld",
+        ":nm",
+        ":objcopy",
+        ":objdump",
+        ":strip",
+    ],
+)

--- a/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-ar
+++ b/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-ar
@@ -1,0 +1,5 @@
+#!/bin/bash --norc
+
+exec -a arm-linux-gnueabihf-ar \
+    external/raspi_components_toolchain_gcc_4_8_3/bin/arm-linux-gnueabihf-ar \
+    "$@"

--- a/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-as
+++ b/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-as
@@ -1,0 +1,5 @@
+#!/bin/bash --norc
+
+exec -a arm-linux-gnueabihf-as \
+    external/raspi_components_toolchain_gcc_4_8_3/bin/arm-linux-gnueabihf-as \
+    "$@"

--- a/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-gcc
+++ b/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-gcc
@@ -1,0 +1,6 @@
+#!/bin/bash --norc
+
+PATH="external/raspi_components_toolchain_gcc_4_8_3/libexec/gcc/arm-linux-gnueabihf/4.9.3:$PATH" \
+    exec \
+    external/raspi_components_toolchain_gcc_4_8_3/bin/arm-linux-gnueabihf-gcc \
+    "$@"

--- a/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-ld
+++ b/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-ld
@@ -1,0 +1,5 @@
+#!/bin/bash --norc
+
+exec -a arm-linux-gnueabihf-ld \
+    external/raspi_components_toolchain_gcc_4_8_3/bin/arm-linux-gnueabihf-ld \
+    "$@"

--- a/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-nm
+++ b/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-nm
@@ -1,0 +1,5 @@
+#!/bin/bash --norc
+
+exec -a arm-linux-gnueabihf-nm \
+    external/raspi_components_toolchain_gcc_4_8_3/bin/arm-linux-gnueabihf-nm \
+    "$@"

--- a/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-objcopy
+++ b/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-objcopy
@@ -1,0 +1,5 @@
+#!/bin/bash --norc
+
+exec -a arm-linux-gnueabihf-objcopy \
+    external/raspi_components_toolchain_gcc_4_8_3/bin/arm-linux-gnueabihf-objcopy \
+    "$@"

--- a/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-objdump
+++ b/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-objdump
@@ -1,0 +1,5 @@
+#!/bin/bash --norc
+
+exec -a arm-linux-gnueabihf-objdump \
+    external/raspi_components_toolchain_gcc_4_8_3/bin/arm-linux-gnueabihf-objdump \
+    "$@"

--- a/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-strip
+++ b/tools/arm_compiler/raspi_linux_gcc/arm-linux-gnueabihf-strip
@@ -1,0 +1,5 @@
+#!/bin/bash --norc
+
+exec -a arm-linux-gnueabihf-strip \
+    external/raspi_components_toolchain_gcc_4_8_3/bin/arm-linux-gnueabihf-strip \
+    "$@"


### PR DESCRIPTION
Uses the Raspbian-patched Linaro toolchain (GCC 4.8.3). Expects `cpu` to be set to `armeabi-v6`.

Also adds Docker-based tests for the system, which it runs in Azure, as well as a README.